### PR TITLE
Allow program to read dependencies from egg files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+dist: xenial
+
+before_install:
+  - sudo wget -qO- https://pkg.musl.cc/chicken-5.0.0/x86_64-linux-musl.tgz | sudo tar --strip-components=1 -C /usr/local -xzf-
+
+install:
+  - chicken-install -no-install
+
+script:
+  - chicken-install -test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: generic
 dist: xenial
 
 before_install:
-  - sudo wget -qO- https://pkg.musl.cc/chicken-5.0.0/x86_64-linux-musl.tgz | sudo tar --strip-components=1 -C /usr/local -xzf-
+  - sudo wget -qO- http://code.call-cc.org/dev-snapshots/2019/01/12/chicken-5.0.1.tar.gz | sudo tar -C /tmp -xzf-
+  - sudo make PLATFORM=linux -C /tmp/chicken-5.0.1 install
 
 install:
   - chicken-install -no-install -sudo

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - sudo wget -qO- https://pkg.musl.cc/chicken-5.0.0/x86_64-linux-musl.tgz | sudo tar --strip-components=1 -C /usr/local -xzf-
 
 install:
-  - chicken-install -no-install
+  - chicken-install -no-install -sudo
 
 script:
-  - chicken-install -test
+  - chicken-install -no-install -sudo -test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: generic
 dist: xenial
 
+cache:
+  directories:
+    - /home/travis/.cache/chicken-install
+
 before_install:
   - sudo wget -qO- http://code.call-cc.org/dev-snapshots/2019/01/12/chicken-5.0.1.tar.gz | sudo tar -C /tmp -xzf-
   - sudo make PLATFORM=linux -C /tmp/chicken-5.0.1 install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cool.
 
 ## Usage
 
-`egg2nix [-v] input.scm > output.nix`
+`egg2nix [-v] file > output.nix`
 
 If you pass `-` instead of an input file, egg2nix will read from
 stdin.

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,6 @@ pkgs.eggDerivation {
 
   name = "egg2nix-0.4";
   buildInputs = with eggs; [
-    matchable http-client args
+    args matchable srfi-1
   ];
 }

--- a/egg2nix.egg
+++ b/egg2nix.egg
@@ -2,5 +2,6 @@
  (author "Moritz Ulrich, Moritz Heidkamp")
  (category tools)
  (license "BSD")
- (dependencies args matchable)
+ (dependencies args matchable srfi-1)
+ (test-dependencies test)
  (components (program egg2nix)))

--- a/eggs.nix
+++ b/eggs.nix
@@ -8,7 +8,7 @@ rec {
     src = fetchegg {
       name = "args";
       version = "1.6.0";
-      sha256 = "1dvzdr7sdpfbc8nnzd1hc3wy7pw9plnbbz5b0skz4p96phqxm803";
+      sha256 = "1y9sznh4kxqxvhd8k44bjx0s7xspp52sx4bn8i8i0f8lwch6r2g4";
     };
 
     buildInputs = [
@@ -24,7 +24,7 @@ rec {
     src = fetchegg {
       name = "matchable";
       version = "1.0";
-      sha256 = "0k2bd5qkcyb3l3gw87g6fx7wyqzb2yvwnlqr5a87nxn9mvqjbg8f";
+      sha256 = "01vy2ppq3sq0wirvsvl3dh0bwa5jqs1i6rdjdd7pnwj4nncxd1ga";
     };
 
     buildInputs = [
@@ -38,7 +38,7 @@ rec {
     src = fetchegg {
       name = "srfi-1";
       version = "0.5";
-      sha256 = "1x78kld3vn9fbnjhk63l7la48fafa6z2nya82mw0k5wnrlfj8c31";
+      sha256 = "0gh1h406xbxwm5gvc5znc93nxp9xjbhyqf7zzga08k5y6igxrlvk";
     };
 
     buildInputs = [
@@ -52,7 +52,7 @@ rec {
     src = fetchegg {
       name = "srfi-13";
       version = "0.2";
-      sha256 = "03hpgx2drwqxk1n3113q6vpj9d8h08df9sq8n3yhfpw37h6zqvxx";
+      sha256 = "0jazbdnn9bjm7wwxqq7xzqxc9zfvaapq565rf1czj6ayl96yvk3n";
     };
 
     buildInputs = [
@@ -66,7 +66,7 @@ rec {
     src = fetchegg {
       name = "srfi-14";
       version = "0.2";
-      sha256 = "0lddw35p1z9fsk6nhn93lj1ljmwx0fjw1yr8g7djw3pk489zjv5b";
+      sha256 = "13nm4nn1d52nkvhjizy26z3s6q41x1ml4zm847xzf86x1zwvymni";
     };
 
     buildInputs = [
@@ -80,7 +80,7 @@ rec {
     src = fetchegg {
       name = "srfi-37";
       version = "1.4";
-      sha256 = "1liiw2gds3f6b8bwl2qgai9aavz5yl9kvkfs1sh2f27a6r07qzia";
+      sha256 = "17f593497n70gldkj6iab6ilgryiqar051v6azn1szhnm1lk7dwd";
     };
 
     buildInputs = [

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,0 +1,65 @@
+(import (test))
+(import (chicken file))
+(import (chicken load))
+(import (chicken port))
+(import (chicken pathname))
+(import (chicken process-context))
+
+(load-relative "../egg2nix.scm")
+
+(import (egg2nix))
+
+(test-begin "egg2nix")
+
+(define (with-clean-directory thunk)
+  (let ((pwd (current-directory))
+        (dir (create-temporary-directory)))
+    (dynamic-wind
+     (lambda ()
+       (set! (current-directory) dir))
+     (lambda () (thunk))
+     (lambda ()
+       (set! (current-directory) pwd)
+       (delete-directory dir #t)))))
+
+(test-group "egg file location"
+  (with-clean-directory
+   (lambda ()
+     (with-output-to-file "foo.egg" void)
+     (test "with a local egg file"
+           (make-pathname (current-directory) "foo.egg")
+           (locate-egg-file))))
+  (with-clean-directory
+   (lambda ()
+     (create-directory "chicken")
+     (with-output-to-file "chicken/foo.egg" void)
+     (test "with an egg file in the chicken directory"
+           (make-pathname (current-directory) "chicken/foo.egg")
+           (locate-egg-file))))
+  (with-clean-directory
+   (lambda ()
+     (test-error "when no egg file is found" (locate-egg-file))))
+  (with-clean-directory
+   (lambda ()
+     (with-output-to-file "foo.egg" void)
+     (with-output-to-file "bar.egg" void)
+     (test-error "when multiple egg files are found" (locate-egg-file)))))
+
+(define (deps str)
+  (with-input-from-string str read-dependencies))
+
+(test-group "input handling"
+  (test-group "dependency list"
+    (test "with no dependencies" '() (deps ""))
+    (test "with a single dependency" '(srfi-1) (deps "srfi-1"))
+    (test "with multiple dependencies" '(srfi-1 args) (deps "srfi-1\nargs"))
+    (test "with a dependency version" '((srfi-1 "1.0")) (deps "(srfi-1 \"1.0\")")))
+  (test-group "egg files"
+    (test "with no dependencies" '() (deps "((components))"))
+    (test "with a single dependency" '(srfi-1) (deps "((components) (dependencies srfi-1))"))
+    (test "with multiple dependencies" '(srfi-1 args) (deps "((components) (dependencies srfi-1 args))"))
+    (test "with a dependency version" '((srfi-1 "1.0")) (deps "((components) (dependencies (srfi-1 \"1.0\")))"))))
+
+(test-end "egg2nix")
+
+(test-exit)


### PR DESCRIPTION
Hi @corngood, I wasn't sure whether this MR should go to you or @the-kenny, but seeing as how your fork is currently the one in use by Nixpkgs I thought I'd start here.

This patch adds support for running `egg2nix foo.egg` (i.e. with an egg file argument) and `egg2nix .` (with a directory), in which case it will read dependencies from the local egg file (documented [here](http://wiki.call-cc.org/man/5/Egg%20specification%20format)).

I tried not to change anything unnecessarily, but I did regenerate `eggs.nix` and add a test suite. Let me know if you'd like those omitted.