### PR TITLE
Some improvements for chicken-5 branch

### DIFF
--- a/egg2nix.scm
+++ b/egg2nix.scm
@@ -321,8 +321,10 @@ exec csi -s "$0" "$@"
   (let* ((eggs (specs->eggs specs))
          (eggs (collect-deps eggs)))
     (print "{ pkgs, stdenv }:")
-    (print "rec {")
+    (print "let")
     (print "  inherit (pkgs) eggDerivation fetchegg;")
+    (print "in")
+    (print "rec {")
     (for-each write-nix-expression eggs)
     (print "}\n")
 

--- a/egg2nix.scm
+++ b/egg2nix.scm
@@ -195,10 +195,11 @@ exec csi -s "$0" "$@"
 
 (define (all-dependencies egg eggs)
   (retrieve-egg egg)
-  (let ((deps (egg-dependencies egg)))
+  (let ((deps (map spec-name (egg-dependencies egg))))
     (egg-deps-set! egg deps)
     (fold (lambda (dep-name eggs)
-            (let ((dep (egg-ref dep-name eggs)))
+            (let* ((dep-name (spec-name dep-name))
+                   (dep (egg-ref dep-name eggs)))
               (if dep
                   eggs
                   (let ((dep (make-egg dep-name)))
@@ -228,19 +229,22 @@ exec csi -s "$0" "$@"
                        "\n      ")
    "\n    ]"))
 
+(define (spec-ref key spec)
+  (and (pair? spec)
+       (pair? (cdr spec))
+       (pair? (cadr spec))
+       (alist-ref key (cdr spec))))
+
 (define (spec-extra-deps spec)
-  (or (and (pair? spec)
-           (alist-ref 'extra-dependencies (cdr spec)))
+  (or (spec-ref 'extra-dependencies spec)
       '()))
 
-(define (spec-broken? entry)
-  (and (pair? entry)
-       (alist-ref 'broken (cdr entry))))
+(define (spec-broken? spec)
+  (spec-ref 'broken spec))
 
 (define (spec-version spec)
-  (and (pair? spec)
-       (car (or (alist-ref 'version (cdr spec))
-                '(#f)))))
+  (car (or (spec-ref 'version spec)
+           '(#f))))
 
 (define (spec-name spec)
   (if (symbol? spec)


### PR DESCRIPTION
Hi there,

first of all, thanks for putting in the effort of making `egg2nix` compatible with CHICKEN 5! During this weekend's [CHICKEN Coding Jam](https://wiki.call-cc.org/event/coding-jam-2021) I picked up the ball on it again and found your branch really helpful :slightly_smiling_face: While experimenting with it, I ran into a few small glitches (cf. [my PR on `nixpkgs`](https://github.com/NixOS/nixpkgs/pull/119085) which you already approved - thanks a lot!) while coming up with some real-world usage examples. See the commit messages for details. With these changes, I was able to make [the mentioned examples work](http://paste.call-cc.org/paste?id=e126731c95836f9a0f1cd084be385fdffa31205b). I have a few more improvement ideas but those will have to wait for the next jam :smile: Hope you agree with the proposed changes! Also, if you don't feel like maintaining this branch yourself any longer, let me know - I'd be happy to!

Cheers
Moritz